### PR TITLE
2: Improve recognition of SPDX license exprs

### DIFF
--- a/report.go
+++ b/report.go
@@ -53,17 +53,7 @@ func report(jsResults string, jsReportOutput string) {
 			le = &licEntry{}
 			le.LicID = l
 
-			// FIXME note that the "valid" field in the report function
-			// FIXME does not currently handle expressions (e.g., using
-			// FIXME AND / OR / + / WITH to describe multiple licenses or
-			// FIXME exceptions; only a single identifier is marked as
-			// FIXME being "valid"
-			_, isSPDX := allLics[l]
-			// also allow NONE and NOASSERTION as valid
-			if l == "NONE" || l == "NOASSERTION" {
-				isSPDX = true
-			}
-			le.IsSPDX = isSPDX
+			le.IsSPDX = spdxlicenses.IsValidExpression(l, allLics)
 
 			le.Deps = []packageVersion{}
 			lics[l] = le


### PR DESCRIPTION
Fixes #2

Still could be improved but this addresses all of the
examples from the test runs I've tried.

Signed-off-by: Steve Winslow <swinslow@gmail.com>